### PR TITLE
Implement Session Start (SS-54)

### DIFF
--- a/src/openvic2/GameManager.cpp
+++ b/src/openvic2/GameManager.cpp
@@ -28,6 +28,7 @@ void GameManager::tick() {
 }
 
 return_t GameManager::setup() {
+	session_start = time(nullptr);
 	clock.reset();
 	today = { 1836 };
 	set_needs_update();

--- a/src/openvic2/GameManager.hpp
+++ b/src/openvic2/GameManager.hpp
@@ -10,6 +10,7 @@ namespace OpenVic2 {
 		Map map;
 		BuildingManager building_manager;
 		GameAdvancementHook clock;
+		time_t session_start; /* SS-54, as well as allowing time-tracking */
 	private:
 		Date today;
 		state_updated_func_t state_updated;


### PR DESCRIPTION
Utilises GameManager's setup method to grab the init time for use as session ID for savegames, as well as setting up potential features in the future such as session time tracking for multiplayer.